### PR TITLE
Improve sql filter construction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -158,8 +158,7 @@ pub fn construct_sql_filter(filter_query: &str) -> String {
 	for label in filter_query.split(';') {
 		if let Some(offender) = label
 			.chars()
-			.filter(|x| !x.is_ascii_alphanumeric() && *x != '.' && *x != ' ' && *x != '-' && *x != '_' && *x != ':')
-			.next()
+			.find(|x| !x.is_ascii_alphanumeric() && !matches!(x, '.' | ' ' | '-' | '_' | ':' | '/' | '(' | ')'))
 		{
 			panic!("invalid character in label filter: {offender:?}");
 		}


### PR DESCRIPTION
## Description

Some nixpkgs labels use `/` and parenthesis,  such as [6.topic: qt/kde](https://nixpkgs-prs.fliegendewurst.eu/?filter=6.topic:%20qt/kde) and [8.has: package (new)](https://nixpkgs-prs.fliegendewurst.eu/?filter=8.has:%20package%20(new)), but it's not possible to search using these labels since the sql filter does not allow those chars.

Also, for `filter().next()`, [clippy suggested](https://rust-lang.github.io/rust-clippy/master/index.html#filter_next) to use `find()` instead and I found that using the [matches!](https://doc.rust-lang.org/std/macro.matches.html) macro can improve the code's readability.

## Changes

- Use `find()` instead of `filter().next()`
- Use `matches!` macro
- Add `/`, `(` and `)` characters for labels